### PR TITLE
Rely on pymodbus reconnect logic

### DIFF
--- a/midas/util.py
+++ b/midas/util.py
@@ -21,6 +21,7 @@ class AsyncioModbusClient(object):
         self.ip = address
         self.timeout = timeout
         self.client = ReconnectingAsyncioModbusTcpClient()
+        asyncio.ensure_future(self._connect())
         self.open = False
         self.waiting = False
 
@@ -101,8 +102,6 @@ class AsyncioModbusClient(object):
         exist, other logic will have to be added to either prevent or manage
         race conditions.
         """
-        if not self.open:
-            await self._connect()
         while self.waiting:
             await asyncio.sleep(0.1)
         if self.client.protocol is None or not self.client.protocol.connected:

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md', 'r') as in_file:
 
 setup(
     name="midas",
-    version="0.4.1",
+    version="0.4.2",
     description="Python driver for Honeywell Midas gas detectors.",
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
So the root of the instability with reconnecting seemed to be related to a conflict between the reconnect logic in the pymobus ReconnectingAsyncioModbusTcpClient and the logic in Util that establishes a connection on each _request. With each _request, a flurry or reconnect attempts were fired off blocking the Midas from accepting any traffic on 502 till the noise died down.

I opted move the initial connect logic into the initialization of the gas detector and let pymodbus handle the reconnects. It has retry logic with increasing back-off that seem to work well.