### PR TITLE
Type all remaining functions

### DIFF
--- a/midas/__init__.py
+++ b/midas/__init__.py
@@ -5,10 +5,12 @@ A Python driver for Honeywell's Midas gas detector, using TCP/IP modbus.
 Distributed under the GNU General Public License v2
 Copyright (C) 2019 NuMat Technologies
 """
+from typing import Any
+
 from midas.driver import GasDetector
 
 
-def command_line(args=None):
+def command_line(args: Any = None) -> None:
     """Command-line tool for Midas gas detector communication."""
     import argparse
     import asyncio
@@ -19,7 +21,7 @@ def command_line(args=None):
     parser.add_argument('address', help="The IP address of the gas detector.")
     args = parser.parse_args(args)
 
-    async def get():
+    async def get() -> None:
         async with GasDetector(args.address) as detector:
             print(json.dumps(await detector.get(), indent=4, sort_keys=True))
 

--- a/midas/driver.py
+++ b/midas/driver.py
@@ -62,29 +62,29 @@ class GasDetector(AsyncioModbusClient):
     you don't have to.
     """
 
-    async def get(self):
+    async def get(self) -> dict:
         """Get current state from the Midas gas detector."""
         return self._parse(await self.read_registers(0, 16))
 
-    async def reset_alarms_and_faults(self):
+    async def reset_alarms_and_faults(self) -> None:
         """Reset all alarms and faults."""
         return await self.write_registers(20, (0x015E, 0x3626))
 
-    async def inhibit_alarms(self):
+    async def inhibit_alarms(self) -> None:
         """Inhibit alarms from triggering."""
         return await self.write_registers(20, (0x025E, 0x3626))
 
-    async def inhibit_alarms_and_faults(self):
+    async def inhibit_alarms_and_faults(self) -> None:
         """Inhibit alarms and faults from triggering."""
         return await self.write_registers(20, (0x035E, 0x3626))
 
-    async def remove_inhibit(self):
+    async def remove_inhibit(self) -> None:
         """Cancel the inhibit state."""
         return await self.write_registers(20, (0x055E, 0x3626))
 
-    def _parse(self, registers):
+    def _parse(self, registers: list) -> dict:
         """Parse the response, returning a dictionary."""
-        result = {'ip': self.ip, 'connected': True}
+        result: dict = {'ip': self.ip, 'connected': True}
         decoder = BinaryPayloadDecoder.fromRegisters(registers,
                                                      byteorder=Endian.Big,
                                                      wordorder=Endian.Little)

--- a/midas/mock.py
+++ b/midas/mock.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from random import random
+from typing import Any
 from unittest.mock import MagicMock
 
 from midas.driver import GasDetector as realGasDetector
@@ -10,7 +11,7 @@ from midas.driver import GasDetector as realGasDetector
 class AsyncClientMock(MagicMock):
     """Magic mock that works with async methods."""
 
-    async def __call__(self, *args, **kwargs):
+    async def __call__(self, *args, **kwargs):  # type: ignore
         """Convert regular mocks into into an async coroutine."""
         return super().__call__(*args, **kwargs)
 
@@ -18,7 +19,7 @@ class AsyncClientMock(MagicMock):
 class GasDetector(realGasDetector):
     """Mock interface to the Midas gas detector."""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Set an inital mocked state."""
         self.client = AsyncClientMock()
         self.state = {
@@ -36,23 +37,23 @@ class GasDetector(realGasDetector):
             "high-alarm threshold": 8,
         }
 
-    def __getattr__(self, attr):
+    def __getattr__(self, attr):  # type: ignore
         """Return False for any undefined method."""
 
-        def handler(*args, **kwargs):
+        def handler(*args, **kwargs):  # type: ignore
             return False
 
         return handler
 
-    async def get(self):
+    async def get(self) -> dict:
         """Return a mock state with the same object structure."""
         await asyncio.sleep(random() * 0.1)
         return self.state
 
-    async def inhibit_alarms(self):
+    async def inhibit_alarms(self) -> None:
         """Inhibit alarms from triggering."""
         self.state["state"] = "Monitoring with alarms inhibited"
 
-    async def remove_inhibit(self):
+    async def remove_inhibit(self) -> None:
         """Cancel the inhibit state."""
         self.state["state"] = "Monitoring"

--- a/midas/util.py
+++ b/midas/util.py
@@ -4,6 +4,7 @@ Distributed under the GNU General Public License v2
 Copyright (C) 2022 NuMat Technologies
 """
 import asyncio
+from typing import Any, Union
 
 try:
     from pymodbus.client import AsyncModbusTcpClient  # 3.x
@@ -21,7 +22,7 @@ class AsyncioModbusClient:
     including standard timeouts, async context manager, and queued requests.
     """
 
-    def __init__(self, address, timeout=1):
+    def __init__(self, address: str, timeout: float = 1) -> None:
         """Set up communication parameters."""
         self.ip = address
         self.timeout = timeout
@@ -33,15 +34,15 @@ class AsyncioModbusClient:
         self.lock = asyncio.Lock()
         self.connectTask = asyncio.create_task(self._connect())
 
-    async def __aenter__(self):
+    async def __aenter__(self) -> Any:
         """Asynchronously connect with the context manager."""
         return self
 
-    async def __aexit__(self, *args):
+    async def __aexit__(self, *args: Any) -> None:
         """Provide exit to the context manager."""
         await self._close()
 
-    async def _connect(self):
+    async def _connect(self) -> None:
         """Start asynchronous reconnect loop."""
         async with self.lock:
             try:
@@ -52,18 +53,18 @@ class AsyncioModbusClient:
             except Exception as e:
                 raise OSError(f"Could not connect to '{self.ip}'.") from e
 
-    async def read_coils(self, address, count):
+    async def read_coils(self, address: int, count: int) -> list:
         """Read modbus output coils (0 address prefix)."""
         return await self._request('read_coils', address, count)
 
-    async def read_registers(self, address, count):
+    async def read_registers(self, address: int, count: int) -> list:
         """Read modbus registers.
 
         The Modbus protocol doesn't allow responses longer than 250 bytes
         (ie. 125 registers, 62 DF addresses), which this function manages by
         chunking larger requests.
         """
-        registers = []
+        registers: list = []
         while count > 124:
             r = await self._request('read_holding_registers', address, 124)
             registers += r.registers
@@ -72,19 +73,21 @@ class AsyncioModbusClient:
         registers += r.registers
         return registers
 
-    async def write_coil(self, address, value):
-        """Write modbus coils."""
+    async def write_coil(self, address: int, value: bool) -> None:
+        """Write a modbus coil."""
         await self._request('write_coil', address, value)
 
-    async def write_coils(self, address, values):
+    async def write_coils(self, address: int, values: list) -> None:
         """Write modbus coils."""
         await self._request('write_coils', address, values)
 
-    async def write_register(self, address, value, skip_encode=False):
+    async def write_register(self, address: int, value: int,
+                             skip_encode: bool = False) -> None:
         """Write a modbus register."""
         await self._request('write_register', address, value, skip_encode=skip_encode)
 
-    async def write_registers(self, address, values, skip_encode=False):
+    async def write_registers(self, address: int, values: Union[list, tuple],
+                              skip_encode: bool = False) -> None:
         """Write modbus registers.
 
         The Modbus protocol doesn't allow requests longer than 250 bytes
@@ -121,7 +124,7 @@ class AsyncioModbusClient:
             except (asyncio.TimeoutError, pymodbus.exceptions.ConnectionException) as e:
                 raise TimeoutError("Not connected to Midas.") from e
 
-    async def _close(self):
+    async def _close(self) -> None:
         """Close the TCP connection."""
         try:
             await self.client.close()  # 3.x

--- a/midas/util.py
+++ b/midas/util.py
@@ -7,7 +7,6 @@ import asyncio
 from typing import Any, Literal, Union, overload
 
 try:
-    from pymodbus.bit_read_message import ReadCoilsResponse
     from pymodbus.client import AsyncModbusTcpClient  # 3.x
     from pymodbus.pdu import ModbusResponse
     from pymodbus.register_read_message import ReadHoldingRegistersResponse
@@ -56,14 +55,6 @@ class AsyncioModbusClient:
             except Exception as e:
                 raise OSError(f"Could not connect to '{self.ip}'.") from e
 
-    async def read_coils(self, address: int, count: int) -> list:
-        """Read modbus output coils (0 address prefix)."""
-        response = await self._request('read_coils', address, count)
-        if isinstance(response, list):
-            return response
-        else:
-            raise OSError("Could not read coils.")
-
     async def read_registers(self, address: int, count: int) -> list:
         """Read modbus registers.
 
@@ -111,11 +102,6 @@ class AsyncioModbusClient:
     @overload
     async def _request(self, method: Literal['read_holding_registers'],
                        *args: Any, **kwargs: Any) -> ReadHoldingRegistersResponse:
-        ...
-
-    @overload
-    async def _request(self, method: Literal['read_coils'],
-                       *args: Any, **kwargs: Any) -> ReadCoilsResponse:
         ...
 
     @overload

--- a/ruff.toml
+++ b/ruff.toml
@@ -23,6 +23,7 @@ select = [
     "YTT", # flake8-2020
     # "ARG", # flake8-unused args
 ]
+target-version = "py38"
 [pydocstyle]
 convention = "pep257"
 [flake8-unused-arguments]

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,8 @@ max-line-length = 99
 
 [mypy]
 check_untyped_defs = True
+allow_untyped_defs = False
+exclude = tests
 [mypy-pymodbus.*]
 ignore_missing_imports = True
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     author="Patrick Fuller",
     author_email="pat@numat-tech.com",
     packages=['midas'],
-    package_data={'midas': ['faults.csv']},
+    package_data={'midas': ['faults.csv', 'py.typed']},
     install_requires=[
         'pymodbus>=2.4.0,<3; python_version == "3.7"',
         'pymodbus>=2.4.0; python_version == "3.8"',


### PR DESCRIPTION
Some type hints were simple to add.  This includes those pymodbus function calls where the response is ignored (such as `write_holding_registers`).

However, some were harder (such as `read_holding_registers`).  These might return either a (subclassed) [`ModbusResponse`](url) or a [`ExceptionResponse`](https://github.com/pymodbus-dev/pymodbus/blob/369d45e7efb1c682077e58e71e63f94745d91bdc/pymodbus/pdu.py#L185) (which is currently unhandled)

I'ved used `@overload` with `Literal[str]` to try to help mypy past the factory functions.  However, it's still not figuring out that `ModbusResponse` should have `bits` and `registers` as attributes (with type `list`).  They are defined [here](https://github.com/pymodbus-dev/pymodbus/blob/369d45e7efb1c682077e58e71e63f94745d91bdc/pymodbus/pdu.py#L124-L148):

```python
class ModbusResponse(ModbusPDU):
    """Base class for a modbus response PDU.

    .. attribute:: should_respond

       A flag that indicates if this response returns a result back
       to the client issuing the request

    .. attribute:: _rtu_frame_size

       Indicates the size of the modbus rtu response used for
       calculating how much to read.
    """

    should_respond = True

    def __init__(self, slave=Defaults.Slave, **kwargs):
        """Proxy the lower level initializer.

        :param slave: Modbus slave slave ID

        """
        super().__init__(slave, **kwargs)
        self.bits = []
        self.registers = []
```
